### PR TITLE
Add OpenAI OAuth refresh tokens, dynamic model fetching, and /import-codex

### DIFF
--- a/src/cli/handlers/auth.ts
+++ b/src/cli/handlers/auth.ts
@@ -12,7 +12,9 @@ import { getSSLErrorHint } from '../../services/api/errorUtils.js'
 import { fetchAndStoreClaudeCodeFirstTokenDate } from '../../services/api/firstTokenDate.js'
 import {
   createAndStoreApiKey,
+  extractAccountIdFromToken,
   fetchAndStoreUserRoles,
+  fetchOpenAICodexModels,
   refreshOAuthToken,
   shouldUseClaudeAIAuth,
   storeOAuthAccountInfo,
@@ -91,33 +93,90 @@ export async function installOAuthTokens(
       activeOpenAIProvider ??
       fallbackOpenAIProvider ??
       providers.find(p => p.kind === 'openai-like' && p.authMode === 'oauth')
+
+    // Extract account ID from JWT and fetch available models
+    const accountId = extractAccountIdFromToken(tokens.accessToken ?? '')
+    let fetchedModels: string[] | undefined
+    if (accountId && tokens.accessToken) {
+      try {
+        fetchedModels = await fetchOpenAICodexModels({
+          accessToken: tokens.accessToken,
+          accountId,
+        })
+      } catch {
+        // Non-fatal: fall back to existing models
+      }
+    }
+
+    const oauthData = {
+      accessToken: tokens.accessToken,
+      refreshToken:
+        typeof tokens.refreshToken === 'string'
+          ? tokens.refreshToken
+          : undefined,
+      expiresAt:
+        typeof tokens.expiresAt === 'number'
+          ? tokens.expiresAt
+          : undefined,
+      accountId,
+    }
     const updatedProviders = targetProvider
       ? providers.map(p =>
-          p === targetProvider ? { ...p, apiKey: tokens.accessToken } : p,
+          p === targetProvider
+            ? {
+                ...p,
+                apiKey: tokens.accessToken,
+                models: fetchedModels ?? p.models,
+                oauth: {
+                  ...oauthData,
+                  refreshToken: oauthData.refreshToken
+                    ?? (p.oauth as { refreshToken?: string } | undefined)?.refreshToken,
+                  expiresAt: oauthData.expiresAt
+                    ?? (p.oauth as { expiresAt?: number } | undefined)?.expiresAt,
+                  accountId: oauthData.accountId
+                    ?? (p.oauth as { accountId?: string } | undefined)?.accountId,
+                },
+              }
+            : p,
         )
-      : providers
+      : [
+          ...providers,
+          {
+            id: 'openai',
+            kind: 'openai-like' as const,
+            authMode: 'oauth' as const,
+            apiKey: tokens.accessToken,
+            models: fetchedModels ?? [],
+            oauth: oauthData,
+          },
+        ]
 
+    const resolvedModels = fetchedModels ?? targetProvider?.models
+    const effectiveProvider = targetProvider ?? {
+      id: 'openai',
+      kind: 'openai-like' as const,
+      authMode: 'oauth' as const,
+    }
     const activeModel =
-      previousStorage.activeProvider === targetProvider?.id
+      previousStorage.activeProvider === effectiveProvider.id
         ? previousStorage.activeModel
-        : targetProvider?.models[0]
+        : resolvedModels?.[0]
     const normalizedOpenAIStorage = {
       ...previousStorage,
-      activeProviderKey: targetProvider
-        ? getProviderKeyFromConfig(targetProvider)
-        : previousStorage.activeProviderKey,
+      activeProviderKey: getProviderKeyFromConfig(effectiveProvider),
       providers: updatedProviders,
-      activeProvider: targetProvider?.id ?? previousStorage.activeProvider,
+      activeProvider: effectiveProvider.id,
       activeModel,
       provider: 'openai' as const,
-      providerKind: targetProvider?.kind ?? 'openai-like',
-      providerId: targetProvider?.id ?? previousStorage.providerId,
+      providerKind: effectiveProvider.kind,
+      providerId: effectiveProvider.id,
+      authMode: effectiveProvider.authMode,
       baseURL: targetProvider?.baseURL ?? previousStorage.baseURL,
       apiKey: tokens.accessToken,
       model: activeModel,
       savedModels:
-        targetProvider?.models ??
-        (previousStorage.activeProvider === targetProvider?.id
+        resolvedModels ??
+        (previousStorage.activeProvider === effectiveProvider.id
           ? previousStorage.savedModels
           : undefined),
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
 import addDir from './commands/add-dir/index.js'
 import addModel from './commands/add-model/index.js'
+import importCodex from './commands/import-codex/index.js'
 import removeModel from './commands/remove-model/index.js'
 import autofixPr from './commands/autofix-pr/index.js'
 import backfillSessions from './commands/backfill-sessions/index.js'
@@ -265,6 +266,7 @@ export const INTERNAL_ONLY_COMMANDS = [
 const COMMANDS = memoize((): Command[] => [
   addDir,
   addModel,
+  importCodex,
   removeModel,
   advisor,
   agents,

--- a/src/commands/import-codex/import-codex.ts
+++ b/src/commands/import-codex/import-codex.ts
@@ -1,0 +1,166 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import type { LocalCommandCall } from '../../types/command.js'
+import { saveGlobalConfig } from '../../utils/config.js'
+import {
+  getProviderKeyFromConfig,
+  readCustomApiStorage,
+  writeCustomApiStorage,
+} from '../../utils/customApiStorage.js'
+import {
+  extractAccountIdFromToken,
+  fetchOpenAICodexModels,
+} from '../../services/oauth/client.js'
+
+type CodexAuthJson = {
+  auth_mode?: string
+  tokens?: {
+    access_token?: string
+    refresh_token?: string
+    id_token?: string
+    account_id?: string
+  }
+}
+
+function findCodexAuthJson(): string | null {
+  const candidates = [
+    path.join(process.env.HOME ?? '', '.codex', 'auth.json'),
+  ]
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p
+  }
+  return null
+}
+
+function decodeJwtExp(token: string): number | undefined {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return undefined
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, 'base64url').toString('utf-8'),
+    )
+    return typeof payload.exp === 'number' ? payload.exp * 1000 : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export const call: LocalCommandCall = async (_args, _context) => {
+  const authPath = findCodexAuthJson()
+  if (!authPath) {
+    return {
+      type: 'text',
+      value: 'Codex credentials not found. Expected ~/.codex/auth.json',
+    }
+  }
+
+  let codexAuth: CodexAuthJson
+  try {
+    codexAuth = JSON.parse(fs.readFileSync(authPath, 'utf-8'))
+  } catch {
+    return {
+      type: 'text',
+      value: `Failed to read ${authPath}`,
+    }
+  }
+
+  const tokens = codexAuth.tokens
+  if (!tokens?.access_token || !tokens.refresh_token) {
+    return {
+      type: 'text',
+      value: 'Codex auth.json is missing access_token or refresh_token. Run `codex login` first.',
+    }
+  }
+
+  const accessToken = tokens.access_token
+  const refreshToken = tokens.refresh_token
+  const expiresAt = decodeJwtExp(accessToken)
+  const accountId =
+    tokens.account_id ?? extractAccountIdFromToken(accessToken)
+
+  // Fetch models dynamically
+  let models: string[] = []
+  if (accountId) {
+    try {
+      models = await fetchOpenAICodexModels({ accessToken, accountId })
+    } catch {
+      // Fall back to empty — user can add manually
+    }
+  }
+
+  const defaultModel = models[0]
+
+  // Build provider config
+  const providerConfig = {
+    id: 'openai',
+    kind: 'openai-like' as const,
+    authMode: 'oauth' as const,
+    apiKey: accessToken,
+    models,
+    oauth: {
+      accessToken,
+      refreshToken,
+      expiresAt,
+      accountId,
+    },
+  }
+
+  // Update secure storage
+  const storage = readCustomApiStorage()
+  const existingProviders = storage.providers ?? []
+  const providerKey = getProviderKeyFromConfig(providerConfig)
+  const providers = [
+    ...existingProviders.filter(
+      p => getProviderKeyFromConfig(p) !== providerKey,
+    ),
+    providerConfig,
+  ]
+
+  writeCustomApiStorage({
+    ...storage,
+    activeProviderKey: providerKey,
+    activeProvider: 'openai',
+    activeModel: defaultModel,
+    activeAuthMode: 'oauth',
+    providers,
+    provider: 'openai',
+    providerKind: 'openai-like',
+    providerId: 'openai',
+    authMode: 'oauth',
+    apiKey: accessToken,
+    model: defaultModel,
+    savedModels: models,
+  })
+
+  // Update global config
+  saveGlobalConfig(current => ({
+    ...current,
+    customApiEndpoint: {
+      ...(current.customApiEndpoint ?? {}),
+      kind: 'openai-like',
+      providerId: 'openai',
+      provider: 'openai',
+      apiKey: undefined,
+      model: defaultModel,
+      savedModels: models,
+    },
+  }))
+
+  // Apply to current process
+  process.env.CLOAI_API_KEY = accessToken
+  process.env.ANTHROPIC_MODEL = defaultModel ?? ''
+
+  const expiryInfo = expiresAt
+    ? ` (expires ${new Date(expiresAt).toLocaleDateString()})`
+    : ''
+
+  return {
+    type: 'text',
+    value: [
+      `Imported Codex credentials from ${authPath}`,
+      `Provider: openai (OAuth)${expiryInfo}`,
+      `Models: ${models.length > 0 ? models.join(', ') : '(none fetched)'}`,
+      defaultModel ? `Active model: ${defaultModel}` : '',
+    ].filter(Boolean).join('\n'),
+  }
+}

--- a/src/commands/import-codex/index.ts
+++ b/src/commands/import-codex/index.ts
@@ -1,0 +1,9 @@
+import type { Command } from '../../commands.js'
+
+export default {
+  type: 'local',
+  name: 'import-codex',
+  description: 'Import OpenAI Codex CLI credentials and models',
+  supportsNonInteractive: false,
+  load: () => import('./import-codex.js'),
+} satisfies Command

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -653,6 +653,13 @@ export function ConsoleOAuthFlow({
       setCustomApiKey('');
       setCustomModels(getProviderModelsInput(persistedCustomApiEndpoint.providers, nextProviderKey));
       setCursorOffset(0);
+      // For official OpenAI OAuth, skip manual model input — models are fetched
+      // dynamically after token exchange via the Codex models API.
+      if (nextAuthMode === 'oauth' && safeOauthStatus.provider === 'openai-like') {
+        setLoginWithClaudeAi(false);
+        setOAuthStatus({ state: 'ready_to_start' });
+        return;
+      }
       setOAuthStatus({
         state: 'custom_config',
         provider: safeOauthStatus.provider,
@@ -1002,7 +1009,7 @@ export function ConsoleOAuthFlow({
             </Box>
           </Box>}
       <Box paddingLeft={1} flexDirection="column" gap={1}>
-        <OAuthStatusMessage oauthStatus={safeOauthStatus} mode={mode} startingMessage={startingMessage} forcedMethodMessage={forcedMethodMessage} showPastePrompt={showPastePrompt} pastedCode={pastedCode} setPastedCode={setPastedCode} cursorOffset={cursorOffset} setCursorOffset={setCursorOffset} textInputColumns={textInputColumns} handleSubmitCode={handleSubmitCode} setOAuthStatus={setOAuthStatus} setLoginWithClaudeAi={setLoginWithClaudeAi} customBaseURL={customBaseURL} customApiKey={customApiKey} customModels={customModels} setCustomBaseURL={setCustomBaseURL} setCustomApiKey={setCustomApiKey} setCustomModels={setCustomModels} isCustomInputPasting={isCustomInputPasting} setIsCustomInputPasting={setIsCustomInputPasting} handleSubmitCustomConfig={handleSubmitCustomConfig} startCompatibleApiConfig={startCompatibleApiConfig} compatibleApiProvider={compatibleApiProvider} persistedProviders={persistedProviders} persistedActiveProvider={persistedActiveProvider} persistedActiveProviderKey={persistedActiveProviderKey} handleOpenProviderActions={handleOpenProviderActions} handleDeleteAccountRequest={handleDeleteAccountRequest} handleDeleteAccountConfirm={handleDeleteAccountConfirm} />
+        <OAuthStatusMessage oauthStatus={safeOauthStatus} mode={mode} startingMessage={startingMessage} forcedMethodMessage={forcedMethodMessage} showPastePrompt={showPastePrompt} pastedCode={pastedCode} setPastedCode={setPastedCode} cursorOffset={cursorOffset} setCursorOffset={setCursorOffset} textInputColumns={textInputColumns} handleSubmitCode={handleSubmitCode} setOAuthStatus={setOAuthStatus} setLoginWithClaudeAi={setLoginWithClaudeAi} customBaseURL={customBaseURL} customApiKey={customApiKey} customModels={customModels} setCustomBaseURL={setCustomBaseURL} setCustomApiKey={setCustomApiKey} setCustomModels={setCustomModels} isCustomInputPasting={isCustomInputPasting} setIsCustomInputPasting={setIsCustomInputPasting} handleSubmitCustomConfig={handleSubmitCustomConfig} startCompatibleApiConfig={startCompatibleApiConfig} compatibleApiProvider={compatibleApiProvider} persistedProviders={persistedProviders} persistedActiveProvider={persistedActiveProvider} persistedActiveProviderKey={persistedActiveProviderKey} handleOpenProviderActions={handleOpenProviderActions} handleDeleteAccountRequest={handleDeleteAccountRequest} handleDeleteAccountConfirm={handleDeleteAccountConfirm} onDone={onDone} />
       </Box>
     </Box>;
 }
@@ -1036,6 +1043,7 @@ type OAuthStatusMessageProps = {
   handleOpenProviderActions: (providerId: string) => void;
   handleDeleteAccountRequest: (providerId: string) => void;
   handleDeleteAccountConfirm: () => void;
+  onDone: () => void;
 };
 
 function OAuthStatusMessage({
@@ -1068,6 +1076,7 @@ function OAuthStatusMessage({
   handleOpenProviderActions,
   handleDeleteAccountRequest,
   handleDeleteAccountConfirm,
+  onDone,
 }: OAuthStatusMessageProps) {
   void isCustomInputPasting;
   void compatibleApiProvider;
@@ -1116,10 +1125,18 @@ function OAuthStatusMessage({
                 label: <Text>Add new account →</Text>,
                 value: '__add_new__' as const,
               },
+              {
+                label: <Text dimColor>Done →</Text>,
+                value: '__done__' as const,
+              },
             ]}
             onChange={value => {
               if (value === '__add_new__') {
                 setOAuthStatus({ state: 'provider_select' });
+                return;
+              }
+              if (value === '__done__') {
+                onDone();
                 return;
               }
               handleOpenProviderActions(value as string);

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -38,6 +38,7 @@ import {
   createOpenAICompatStream,
   createOpenAICodexStream,
   createOpenAIResponsesStream,
+  refreshOpenAIProviderOAuthIfNeeded,
 } from './openaiCompat.js'
 import {
   convertAnthropicRequestToGemini,
@@ -1847,6 +1848,8 @@ async function* queryModel(
             (activeProviderId === 'openai' ? 'oauth' : 'chat-completions')
 
           if (openAIAuthMode === 'oauth') {
+            // Refresh OpenAI OAuth token if expired (like Gemini OAuth pattern)
+            await refreshOpenAIProviderOAuthIfNeeded()
             const openAICodexRequest = convertAnthropicRequestToOpenAICodex({
               model: params.model,
               system: params.system,

--- a/src/services/api/openaiCompat.ts
+++ b/src/services/api/openaiCompat.ts
@@ -7,8 +7,85 @@ import type {
   BetaToolUnion,
   BetaUsage,
 } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
-import { readCustomApiStorage } from '../../utils/customApiStorage.js'
+import { type ProviderConfig, getActiveProviderConfig, readCustomApiStorage, writeCustomApiStorage } from '../../utils/customApiStorage.js'
 import { getOpenAIReasoningConfig } from '../../utils/modelReasoning.js'
+import { fetchOpenAICodexModels, refreshOpenAIOAuthToken } from '../oauth/client.js'
+
+export async function refreshOpenAIProviderOAuthIfNeeded(): Promise<ProviderConfig> {
+  const storage = readCustomApiStorage()
+  const provider = getActiveProviderConfig(storage)
+  if (!provider || provider.kind !== 'openai-like' || provider.authMode !== 'oauth') {
+    throw new Error('Active OpenAI OAuth provider not found')
+  }
+  const oauth = provider.oauth as { accessToken?: string; refreshToken?: string; expiresAt?: number; accountId?: string } | undefined
+  // No oauth metadata stored (legacy) — use apiKey as-is
+  if (!oauth?.accessToken) {
+    return provider
+  }
+  // Token still valid
+  if (!oauth.expiresAt || oauth.expiresAt > Date.now()) {
+    return provider
+  }
+  // Expired but no refresh token — use apiKey as-is (will likely 401)
+  if (!oauth.refreshToken) {
+    return provider
+  }
+
+  const refreshed = await refreshOpenAIOAuthToken({
+    refreshToken: oauth.refreshToken,
+  })
+
+  // Also refresh the model list (non-fatal if it fails)
+  let freshModels: string[] | undefined
+  if (oauth.accountId) {
+    try {
+      freshModels = await fetchOpenAICodexModels({
+        accessToken: refreshed.accessToken,
+        accountId: oauth.accountId,
+      })
+    } catch {
+      // Keep existing models
+    }
+  }
+
+  const providers = (storage.providers ?? []).map(item =>
+    item.kind === provider.kind &&
+    item.id === provider.id &&
+    item.authMode === provider.authMode
+      ? {
+          ...item,
+          apiKey: refreshed.accessToken,
+          models: freshModels ?? item.models,
+          oauth: {
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+            expiresAt: refreshed.expiresAt,
+            accountId: oauth.accountId,
+          },
+        }
+      : item,
+  )
+
+  writeCustomApiStorage({
+    ...storage,
+    apiKey: refreshed.accessToken,
+    savedModels: freshModels ?? storage.savedModels,
+    providers,
+  })
+
+  // Update process env so downstream code picks up the new token
+  process.env.CLOAI_API_KEY = refreshed.accessToken
+
+  const nextProvider = providers.find(item =>
+    item.kind === provider.kind &&
+    item.id === provider.id &&
+    item.authMode === provider.authMode,
+  )
+  if (!nextProvider) {
+    throw new Error('Failed to persist refreshed OpenAI OAuth tokens')
+  }
+  return nextProvider
+}
 
 type AnyBlock = Record<string, unknown>
 

--- a/src/services/oauth/client.ts
+++ b/src/services/oauth/client.ts
@@ -326,6 +326,92 @@ export async function refreshOAuthToken(
   }
 }
 
+export async function refreshOpenAIOAuthToken(input: {
+  refreshToken: string
+  clientId?: string
+}): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> {
+  const clientId = input.clientId ?? OPENAI_CLIENT_ID
+  const requestBody = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: input.refreshToken,
+    client_id: clientId,
+  })
+
+  const response = await axios.post(OPENAI_TOKEN_URL, requestBody.toString(), {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    timeout: 15000,
+  })
+
+  if (response.status !== 200) {
+    throw new Error(`OpenAI token refresh failed: ${response.statusText}`)
+  }
+
+  const data = response.data
+  logEvent('tengu_oauth_token_refresh_success', { oauthProvider: 'openai' })
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token || input.refreshToken,
+    expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000 - 5 * 60 * 1000,
+  }
+}
+
+const OPENAI_CODEX_MODELS_URL = 'https://chatgpt.com/backend-api/codex/models'
+const OPENAI_CODEX_CLIENT_VERSION = '0.118.0'
+
+/**
+ * Extract the ChatGPT account ID from an OpenAI OAuth access token JWT.
+ */
+export function extractAccountIdFromToken(accessToken: string): string | undefined {
+  try {
+    const parts = accessToken.split('.')
+    if (parts.length !== 3) return undefined
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, 'base64url').toString('utf-8'),
+    )
+    return (
+      payload?.['https://api.openai.com/auth']?.chatgpt_account_id ??
+      undefined
+    )
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Fetch the curated Codex model list from OpenAI's backend API.
+ * Returns model slugs sorted by priority (ascending), filtered to visible + API-supported.
+ */
+export async function fetchOpenAICodexModels(input: {
+  accessToken: string
+  accountId: string
+}): Promise<string[]> {
+  const response = await axios.get(OPENAI_CODEX_MODELS_URL, {
+    params: { client_version: OPENAI_CODEX_CLIENT_VERSION },
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+      'ChatGPT-Account-Id': input.accountId,
+    },
+    timeout: 15000,
+  })
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch OpenAI Codex models: ${response.statusText}`)
+  }
+
+  const models = (response.data?.models ?? []) as Array<{
+    slug: string
+    visibility?: string
+    supported_in_api?: boolean
+    priority?: number
+  }>
+
+  return models
+    .filter(m => m.visibility === 'list' && m.supported_in_api !== false)
+    .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
+    .map(m => m.slug)
+}
+
 export async function fetchAndStoreUserRoles(
   accessToken: string,
 ): Promise<void> {

--- a/src/utils/customApiStorage.ts
+++ b/src/utils/customApiStorage.ts
@@ -17,6 +17,13 @@ export type GeminiOAuthConfig = {
   email?: string
 }
 
+export type OpenAIOAuthConfig = {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: number
+  accountId?: string
+}
+
 export type ActiveCustomApiEndpoint = {
   kind?: CompatibleProviderKind
   providerId?: string
@@ -41,7 +48,7 @@ export type ProviderConfig = {
   apiKey?: string
   models: string[]
   reasoning?: ProviderReasoningConfig
-  oauth?: GeminiOAuthConfig
+  oauth?: GeminiOAuthConfig | OpenAIOAuthConfig
 }
 
 export type CustomApiStorageData = {


### PR DESCRIPTION
## Summary
- **OAuth refresh tokens**: Store and auto-refresh OpenAI OAuth tokens (previously discarded refresh_token and expiresAt). Mirrors the existing Gemini OAuth refresh pattern.
- **Dynamic model fetching**: Fetch available models from OpenAI's Codex models API (`chatgpt.com/backend-api/codex/models`) after OAuth login and on token refresh. Skip the manual "enter models" step for OpenAI OAuth.
- **`/import-codex` command**: One-step credential migration from Codex CLI (`~/.codex/auth.json`), including access token, refresh token, account ID, and dynamic model list.

## Files changed
| Area | Files |
|------|-------|
| Types | `customApiStorage.ts` — `OpenAIOAuthConfig` with `accountId` |
| Token refresh | `oauth/client.ts`, `openaiCompat.ts` — refresh + model fetch |
| Login flow | `auth.ts` — store refresh token, fetch models on OAuth |
| UX | `ConsoleOAuthFlow.tsx` — skip model step for OAuth |
| API wiring | `claude.ts` — pre-request token refresh |
| New command | `commands/import-codex/` + `commands.ts` |

## Test plan
- [x] `/login` → select OpenAI OAuth → verify models are auto-populated (no manual input)
- [ ] Check `~/.cloai/.credentials.json` has `oauth.refreshToken`, `oauth.expiresAt`, `oauth.accountId`
- [ ] `/import-codex` with a valid `~/.codex/auth.json` → verify credentials imported with models
- [ ] Set `oauth.expiresAt` to past → make a request → verify token auto-refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)