### PR TITLE
.3863056974089704:3939b7f63eb35552a97d5586f5e2880e_69e0bc7661cc450651bd1be1.69e0bce961cc450651bd1be5.69e0bce85633167467844f2f:Trae CN.T(2026/4/16 18:41:45)

### DIFF
--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -81,7 +81,7 @@ type Setting = (SettingBase & {
   onChange(value: string): void;
   type: 'managedEnum';
 });
-type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'ExternalIncludes' | 'OutputStyle' | 'ChannelDowngrade' | 'Language' | 'EnableAutoUpdates' | 'SamplingTemperature';
+type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'ExternalIncludes' | 'OutputStyle' | 'ChannelDowngrade' | 'Language' | 'EnableAutoUpdates' | 'SamplingTemperature' | 'MaxConsecutiveIdenticalToolCalls' | 'MaxApiRetries';
 export function Config({
   onClose,
   context,
@@ -108,6 +108,8 @@ export function Config({
   const [customApiKey, setCustomApiKey] = useState(getGlobalConfig().customApiEndpoint?.apiKey ?? '');
   const [customModelValue, setCustomModelValue] = useState(getGlobalConfig().customApiEndpoint?.model ?? process.env.ANTHROPIC_MODEL ?? '');
   const [samplingTemperatureCustomValue, setSamplingTemperatureCustomValue] = useState(() => settingsData?.samplingTemperature !== undefined && typeof settingsData.samplingTemperature === 'number' ? String(settingsData.samplingTemperature) : '1');
+  const [maxConsecutiveIdenticalToolCallsCustomValue, setMaxConsecutiveIdenticalToolCallsCustomValue] = useState(() => settingsData?.maxConsecutiveIdenticalToolCalls !== undefined && typeof settingsData.maxConsecutiveIdenticalToolCalls === 'number' ? String(settingsData.maxConsecutiveIdenticalToolCalls) : '5');
+  const [maxApiRetriesCustomValue, setMaxApiRetriesCustomValue] = useState(() => settingsData?.maxApiRetries !== undefined && typeof settingsData.maxApiRetries === 'number' ? String(settingsData.maxApiRetries) : '15');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollOffset, setScrollOffset] = useState(0);
   const [isSearchMode, setIsSearchMode] = useState(true);
@@ -267,6 +269,12 @@ export function Config({
   const samplingTemperatureValue = settingsData?.samplingTemperature;
   const samplingTemperatureDisplayValue = samplingTemperatureValue === undefined ? 'default' : typeof samplingTemperatureValue === 'number' ? `custom (${samplingTemperatureValue})` : samplingTemperatureValue;
 
+  const maxConsecutiveIdenticalToolCallsValue = settingsData?.maxConsecutiveIdenticalToolCalls;
+  const maxConsecutiveIdenticalToolCallsDisplayValue = maxConsecutiveIdenticalToolCallsValue === undefined || maxConsecutiveIdenticalToolCallsValue === 'default' ? 'default (5)' : typeof maxConsecutiveIdenticalToolCallsValue === 'number' ? `custom (${maxConsecutiveIdenticalToolCallsValue})` : maxConsecutiveIdenticalToolCallsValue;
+
+  const maxApiRetriesValue = settingsData?.maxApiRetries;
+  const maxApiRetriesDisplayValue = maxApiRetriesValue === undefined || maxApiRetriesValue === 'default' ? 'default (15)' : typeof maxApiRetriesValue === 'number' ? `custom (${maxApiRetriesValue})` : maxApiRetriesValue;
+
   // TODO: Add MCP servers
   const settingsItems: Setting[] = [
   // Global settings
@@ -377,6 +385,18 @@ export function Config({
     id: 'samplingTemperature',
     label: 'Sampling temperature',
     value: samplingTemperatureDisplayValue,
+    type: 'managedEnum' as const,
+    onChange() {}
+  }, {
+    id: 'maxConsecutiveIdenticalToolCalls',
+    label: 'Max consecutive identical tool calls',
+    value: maxConsecutiveIdenticalToolCallsDisplayValue,
+    type: 'managedEnum' as const,
+    onChange() {}
+  }, {
+    id: 'maxApiRetries',
+    label: 'Max API retries',
+    value: maxApiRetriesDisplayValue,
     type: 'managedEnum' as const,
     onChange() {}
   }, {
@@ -1266,6 +1286,14 @@ export function Config({
       const label = settingsData?.samplingTemperature === undefined ? 'Reset sampling temperature to default' : `Set sampling temperature to ${chalk.bold(String(settingsData.samplingTemperature))}`;
       formattedChanges.push(label);
     }
+    if (settingsData?.maxConsecutiveIdenticalToolCalls !== initialSettingsData.current?.maxConsecutiveIdenticalToolCalls) {
+      const label = settingsData?.maxConsecutiveIdenticalToolCalls === undefined || settingsData?.maxConsecutiveIdenticalToolCalls === 'default' ? 'Reset max consecutive identical tool calls to default' : `Set max consecutive identical tool calls to ${chalk.bold(String(settingsData.maxConsecutiveIdenticalToolCalls))}`;
+      formattedChanges.push(label);
+    }
+    if (settingsData?.maxApiRetries !== initialSettingsData.current?.maxApiRetries) {
+      const label = settingsData?.maxApiRetries === undefined || settingsData?.maxApiRetries === 'default' ? 'Reset max API retries to default' : `Set max API retries to ${chalk.bold(String(settingsData.maxApiRetries))}`;
+      formattedChanges.push(label);
+    }
     if (formattedChanges.length > 0) {
       onClose(formattedChanges.join('\n'));
     } else {
@@ -1273,7 +1301,7 @@ export function Config({
         display: 'system'
       });
     }
-  }, [showSubmenu, changes, globalConfig, mainLoopModel, currentOutputStyle, currentLanguage, settingsData?.autoUpdatesChannel, settingsData?.samplingTemperature, isFastModeEnabled() ? (settingsData as Record<string, unknown> | undefined)?.fastMode : undefined, onClose]);
+  }, [showSubmenu, changes, globalConfig, mainLoopModel, currentOutputStyle, currentLanguage, settingsData?.autoUpdatesChannel, settingsData?.samplingTemperature, settingsData?.maxConsecutiveIdenticalToolCalls, settingsData?.maxApiRetries, isFastModeEnabled() ? (settingsData as Record<string, unknown> | undefined)?.fastMode : undefined, onClose]);
 
   // Restore all state stores to their mount-time snapshots. Changes are
   // applied to disk/AppState immediately on toggle, so "cancel" means
@@ -1300,6 +1328,50 @@ export function Config({
     resetCursorOnUpdate: true
   }];
 
+  const maxConsecutiveIdenticalToolCallsOptions: OptionWithDescription[] = [{
+    label: 'Default',
+    value: 'default',
+    description: 'Use the built-in limit of 5 consecutive identical tool calls.'
+  }, {
+    type: 'input',
+    label: 'Custom',
+    value: 'custom',
+    description: 'Set a custom maximum number of consecutive identical tool calls.',
+    placeholder: 'Positive integer',
+    initialValue: maxConsecutiveIdenticalToolCallsCustomValue,
+    onChange: setMaxConsecutiveIdenticalToolCallsCustomValue,
+    allowEmptySubmitToCancel: true,
+    showLabelWithValue: true,
+    labelValueSeparator: ': ',
+    resetCursorOnUpdate: true
+  }];
+
+  const maxApiRetriesOptions: OptionWithDescription[] = [{
+    label: 'Default',
+    value: 'default',
+    description: 'Use the built-in limit of 15 retry attempts.'
+  }, {
+    label: 'Off',
+    value: 'off',
+    description: 'Disable retries (0 attempts).'
+  }, {
+    label: 'Always',
+    value: 'always',
+    description: 'Retry indefinitely until the request succeeds.'
+  }, {
+    type: 'input',
+    label: 'Custom',
+    value: 'custom',
+    description: 'Set a custom maximum number of retry attempts.',
+    placeholder: 'Non-negative integer',
+    initialValue: maxApiRetriesCustomValue,
+    onChange: setMaxApiRetriesCustomValue,
+    allowEmptySubmitToCancel: true,
+    showLabelWithValue: true,
+    labelValueSeparator: ': ',
+    resetCursorOnUpdate: true
+  }];
+
   const revertChanges = useCallback(() => {
     // Theme: restores ThemeProvider React state. Must run before the global
     // config overwrite since setTheme internally calls saveGlobalConfig with
@@ -1319,7 +1391,9 @@ export function Config({
       prefersReducedMotion: il?.prefersReducedMotion,
       defaultView: il?.defaultView,
       outputStyle: il?.outputStyle,
-      samplingTemperature: il?.samplingTemperature
+      samplingTemperature: il?.samplingTemperature,
+      maxConsecutiveIdenticalToolCalls: il?.maxConsecutiveIdenticalToolCalls,
+      maxApiRetries: il?.maxApiRetries
     });
     const iu = initialUserSettings;
     updateSettingsForSource('userSettings', {
@@ -1423,7 +1497,7 @@ export function Config({
       }
       return;
     }
-    if (setting_0.id === 'theme' || setting_0.id === 'model' || setting_0.id === 'teammateDefaultModel' || setting_0.id === 'showExternalIncludesDialog' || setting_0.id === 'outputStyle' || setting_0.id === 'language' || setting_0.id === 'samplingTemperature') {
+    if (setting_0.id === 'theme' || setting_0.id === 'model' || setting_0.id === 'teammateDefaultModel' || setting_0.id === 'showExternalIncludesDialog' || setting_0.id === 'outputStyle' || setting_0.id === 'language' || setting_0.id === 'samplingTemperature' || setting_0.id === 'maxConsecutiveIdenticalToolCalls' || setting_0.id === 'maxApiRetries') {
       // managedEnum items open a submenu — isDirty is set by the submenu's
       // completion callback, not here (submenu may be cancelled).
       switch (setting_0.id) {
@@ -1453,6 +1527,14 @@ export function Config({
           return;
         case 'samplingTemperature':
           setShowSubmenu('SamplingTemperature');
+          setTabsHidden(true);
+          return;
+        case 'maxConsecutiveIdenticalToolCalls':
+          setShowSubmenu('MaxConsecutiveIdenticalToolCalls');
+          setTabsHidden(true);
+          return;
+        case 'maxApiRetries':
+          setShowSubmenu('MaxApiRetries');
           setTabsHidden(true);
           return;
       }
@@ -1832,6 +1914,126 @@ export function Config({
           samplingTemperature: parsed
         }));
         setSamplingTemperatureCustomValue(String(parsed));
+        setShowSubmenu(null);
+        setTabsHidden(false);
+      }} />
+            <Text dimColor>
+              <Byline>
+                <KeyboardShortcutHint shortcut="Enter" action="confirm" />
+                <ConfigurableShortcutHint action="confirm:no" context="Settings" fallback="Esc" description="cancel" />
+              </Byline>
+            </Text>
+          </Dialog> : showSubmenu === 'MaxConsecutiveIdenticalToolCalls' ? <Dialog title="Max consecutive identical tool calls" onCancel={() => {
+      setShowSubmenu(null);
+      setTabsHidden(false);
+    }} hideBorder hideInputGuide>
+            <Text>
+              Set the maximum number of consecutive identical tool calls before stopping.
+            </Text>
+            <Text dimColor>
+              Default uses 5. Custom lets you set a positive integer.
+            </Text>
+            <Select options={maxConsecutiveIdenticalToolCallsOptions} onChange={(value: string) => {
+        if (value === 'default') {
+          isDirty.current = true;
+          updateSettingsForSource('localSettings', {
+            maxConsecutiveIdenticalToolCalls: undefined
+          });
+          setSettingsData(prev_31 => ({
+            ...prev_31,
+            maxConsecutiveIdenticalToolCalls: undefined
+          }));
+          setShowSubmenu(null);
+          setTabsHidden(false);
+          return;
+        }
+        const parsed = Number(maxConsecutiveIdenticalToolCallsCustomValue);
+        if (!Number.isFinite(parsed) || parsed < 1 || !Number.isInteger(parsed)) {
+          logError(new Error('Max consecutive identical tool calls must be a positive integer'));
+          return;
+        }
+        isDirty.current = true;
+        updateSettingsForSource('localSettings', {
+          maxConsecutiveIdenticalToolCalls: parsed
+        });
+        setSettingsData(prev_32 => ({
+          ...prev_32,
+          maxConsecutiveIdenticalToolCalls: parsed
+        }));
+        setMaxConsecutiveIdenticalToolCallsCustomValue(String(parsed));
+        setShowSubmenu(null);
+        setTabsHidden(false);
+      }} />
+            <Text dimColor>
+              <Byline>
+                <KeyboardShortcutHint shortcut="Enter" action="confirm" />
+                <ConfigurableShortcutHint action="confirm:no" context="Settings" fallback="Esc" description="cancel" />
+              </Byline>
+            </Text>
+          </Dialog> : showSubmenu === 'MaxApiRetries' ? <Dialog title="Max API retries" onCancel={() => {
+      setShowSubmenu(null);
+      setTabsHidden(false);
+    }} hideBorder hideInputGuide>
+            <Text>
+              Set the maximum number of API retry attempts.
+            </Text>
+            <Text dimColor>
+              Default uses 15. Off disables retries. Always retries indefinitely. Custom lets you set a non-negative integer.
+            </Text>
+            <Select options={maxApiRetriesOptions} onChange={(value: string) => {
+        if (value === 'default') {
+          isDirty.current = true;
+          updateSettingsForSource('localSettings', {
+            maxApiRetries: undefined
+          });
+          setSettingsData(prev_33 => ({
+            ...prev_33,
+            maxApiRetries: undefined
+          }));
+          setShowSubmenu(null);
+          setTabsHidden(false);
+          return;
+        }
+        if (value === 'off') {
+          isDirty.current = true;
+          updateSettingsForSource('localSettings', {
+            maxApiRetries: 'off'
+          });
+          setSettingsData(prev_34 => ({
+            ...prev_34,
+            maxApiRetries: 'off'
+          }));
+          setShowSubmenu(null);
+          setTabsHidden(false);
+          return;
+        }
+        if (value === 'always') {
+          isDirty.current = true;
+          updateSettingsForSource('localSettings', {
+            maxApiRetries: 'always'
+          });
+          setSettingsData(prev_35 => ({
+            ...prev_35,
+            maxApiRetries: 'always'
+          }));
+          setShowSubmenu(null);
+          setTabsHidden(false);
+          return;
+        }
+        const parsed = Number(maxApiRetriesCustomValue);
+        if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+          logError(new Error('Max API retries must be a non-negative integer'));
+          return;
+        }
+        isDirty.current = true;
+        updateSettingsForSource('localSettings', {
+          maxApiRetries: parsed
+        });
+        setSettingsData(prev_36 => ({
+          ...prev_36,
+          maxApiRetries: parsed
+        }));
+        setMaxApiRetriesCustomValue(String(parsed));
         setShowSubmenu(null);
         setTabsHidden(false);
       }} />

--- a/src/query.ts
+++ b/src/query.ts
@@ -1825,7 +1825,7 @@ async function* queryLoop(
         lastToolLoopFingerprint = toolLoopFingerprint
         consecutiveIdenticalToolBatchCount = 1
       }
-      if (!shouldForceSerialToolExecution && consecutiveIdenticalToolBatchCount >= 5) {
+      if (!shouldForceSerialToolExecution && consecutiveIdenticalToolBatchCount >= config.settings.maxConsecutiveIdenticalToolCalls) {
         const errorMessage =
           'The model repeated the same tool calls with identical inputs after receiving their results. Stopping to avoid an infinite tool loop. Please retry the request if you still need to continue.'
         yield createAssistantAPIErrorMessage({

--- a/src/query/config.ts
+++ b/src/query/config.ts
@@ -2,6 +2,9 @@ import { getSessionId } from '../bootstrap/state.js'
 import { checkStatsigFeatureGate_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'
 import type { SessionId } from '../types/ids.js'
 import { isEnvTruthy } from '../utils/envUtils.js'
+import { getInitialSettings } from '../utils/settings/settings.js'
+
+const DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 5
 
 // -- config
 
@@ -24,9 +27,22 @@ export type QueryConfig = {
     isAnt: boolean
     fastModeEnabled: boolean
   }
+
+  // User-configurable settings.
+  settings: {
+    maxConsecutiveIdenticalToolCalls: number
+  }
 }
 
 export function buildQueryConfig(): QueryConfig {
+  const settings = getInitialSettings()
+  const maxConsecutiveIdenticalToolCalls = settings.maxConsecutiveIdenticalToolCalls
+
+  let resolvedMaxConsecutiveIdenticalToolCalls = DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS
+  if (typeof maxConsecutiveIdenticalToolCalls === 'number') {
+    resolvedMaxConsecutiveIdenticalToolCalls = Math.max(1, maxConsecutiveIdenticalToolCalls)
+  }
+
   return {
     sessionId: getSessionId(),
     gates: {
@@ -41,6 +57,9 @@ export function buildQueryConfig(): QueryConfig {
       // (axios, settings, auth, model, oauth, config) into test shards that
       // didn't previously load it — changes init order and breaks unrelated tests.
       fastModeEnabled: !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_FAST_MODE),
+    },
+    settings: {
+      maxConsecutiveIdenticalToolCalls: resolvedMaxConsecutiveIdenticalToolCalls,
     },
   }
 }

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -12,6 +12,7 @@ import { logForDebugging } from 'src/utils/debug.js'
 import { logError } from 'src/utils/log.js'
 import { createSystemAPIErrorMessage } from 'src/utils/messages.js'
 import { getAPIProviderForStatsig } from 'src/utils/model/providers.js'
+import { getInitialSettings } from '../../utils/settings/settings.js'
 import {
   clearApiKeyHelperCache,
   clearAwsCredentialsCache,
@@ -98,6 +99,10 @@ const PERSISTENT_RESET_CAP_MS = 6 * 60 * 60 * 1000
 const HEARTBEAT_INTERVAL_MS = 30_000
 
 function isPersistentRetryEnabled(): boolean {
+  const settings = getInitialSettings()
+  if (settings.maxApiRetries === 'always') {
+    return true
+  }
   return feature('UNATTENDED_RETRY')
     ? isEnvTruthy(process.env.CLAUDE_CODE_UNATTENDED_RETRY)
     : false
@@ -793,6 +798,19 @@ function shouldRetry(error: APIError): boolean {
 }
 
 export function getDefaultMaxRetries(): number {
+  const settings = getInitialSettings()
+  const maxApiRetries = settings.maxApiRetries
+
+  if (maxApiRetries === 'off') {
+    return 0
+  }
+  if (typeof maxApiRetries === 'number') {
+    return Math.max(0, maxApiRetries)
+  }
+  if (maxApiRetries === 'always') {
+    return Number.MAX_SAFE_INTEGER
+  }
+
   if (process.env.CLAUDE_CODE_MAX_RETRIES) {
     return parseInt(process.env.CLAUDE_CODE_MAX_RETRIES, 10)
   }

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -392,6 +392,26 @@ export const SettingsSchema = lazySchema(() =>
         .describe(
           'Override sampling temperature for request construction. Use default to preserve current behavior, off to omit temperature, or a number between 0 and 2.',
         ),
+      maxConsecutiveIdenticalToolCalls: z
+        .union([
+          z.literal('default'),
+          z.number().int().positive(),
+        ])
+        .optional()
+        .describe(
+          'Maximum number of consecutive identical tool calls before stopping to avoid infinite loops. Default is 5. Use default to use the built-in limit, or a positive integer for a custom limit.',
+        ),
+      maxApiRetries: z
+        .union([
+          z.literal('default'),
+          z.literal('off'),
+          z.literal('always'),
+          z.number().int().nonnegative(),
+        ])
+        .optional()
+        .describe(
+          'Maximum number of API retry attempts. Default is 15. Use default to use the built-in limit, off to disable retries (0), always for persistent retries, or a non-negative integer for a custom limit.',
+        ),
       // Enterprise allowlist of models
       availableModels: z
         .array(z.string())


### PR DESCRIPTION
1. 将 API 重试次数加入配置列表，支持 default / off / always / custom 设置
2. 将重复工具调用强制终止轮数加入配置列表，支持 default / custom 设置
3. 补充说明：maxConsecutiveIdenticalToolCalls 当前通过 src/query/config.ts 直接读取 settings，存在把 settings 模块依赖链引入 query 配置层的风险，后续可考虑改为在更外层读取后再传入纯数值配置