### PR TITLE
.3863056974089704:7ffafb679ab7cb7bfa381e66bbdad849_69e0bc7661cc450651bd1be1.69e0c5a361cc450651bd1d2e.69e0c5a35633167467844f30:Trae CN.T(2026/4/16 19:18:59)

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -101,7 +101,8 @@ import { runTools } from './services/tools/toolOrchestration.js'
 import { applyToolResultBudget } from './utils/toolResultStorage.js'
 import { recordContentReplacement } from './utils/sessionStorage.js'
 import { handleStopHooks } from './query/stopHooks.js'
-import { buildQueryConfig } from './query/config.js'
+import { buildQueryConfig, DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS } from './query/config.js'
+import { getInitialSettings } from './utils/settings/settings.js'
 import { productionDeps, type QueryDeps } from './query/deps.js'
 import type { Terminal, Continue } from './query/transitions.js'
 import { feature } from 'bun:bundle'
@@ -379,7 +380,14 @@ async function* queryLoop(
 
   // Snapshot immutable env/statsig/session state once at entry. See QueryConfig
   // for what's included and why feature() gates are intentionally excluded.
-  const config = buildQueryConfig()
+  const settings = getInitialSettings()
+  let maxConsecutiveIdenticalToolCallsOverride: number | undefined
+  if (typeof settings.maxConsecutiveIdenticalToolCalls === 'number') {
+    maxConsecutiveIdenticalToolCallsOverride = Math.max(1, settings.maxConsecutiveIdenticalToolCalls)
+  }
+  const config = buildQueryConfig({
+    maxConsecutiveIdenticalToolCalls: maxConsecutiveIdenticalToolCallsOverride,
+  })
 
   // Fired once per user turn — the prompt is invariant across loop iterations,
   // so per-iteration firing would ask sideQuery the same question N times.

--- a/src/query/config.ts
+++ b/src/query/config.ts
@@ -2,9 +2,8 @@ import { getSessionId } from '../bootstrap/state.js'
 import { checkStatsigFeatureGate_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'
 import type { SessionId } from '../types/ids.js'
 import { isEnvTruthy } from '../utils/envUtils.js'
-import { getInitialSettings } from '../utils/settings/settings.js'
 
-const DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 5
+export const DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 5
 
 // -- config
 
@@ -34,9 +33,12 @@ export type QueryConfig = {
   }
 }
 
-export function buildQueryConfig(): QueryConfig {
-  const settings = getInitialSettings()
-  const maxConsecutiveIdenticalToolCalls = settings.maxConsecutiveIdenticalToolCalls
+export type QueryConfigOverrides = {
+  maxConsecutiveIdenticalToolCalls?: number
+}
+
+export function buildQueryConfig(overrides?: QueryConfigOverrides): QueryConfig {
+  const maxConsecutiveIdenticalToolCalls = overrides?.maxConsecutiveIdenticalToolCalls
 
   let resolvedMaxConsecutiveIdenticalToolCalls = DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS
   if (typeof maxConsecutiveIdenticalToolCalls === 'number') {


### PR DESCRIPTION
1. 修复 query config 的 settings 接线方式，将 maxConsecutiveIdenticalToolCalls 的读取上移到 query.ts，再以纯数值 override 传入 buildQueryConfig
2. 保持 query/config.ts 作为轻量配置构造层，避免直接在该层引入 settings 模块依赖
3. 存在问题：额外引入了 DEFAULT_MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS，但当前文件里没有使用它